### PR TITLE
Output files into correct directory.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -31,7 +31,7 @@ var _minifyImage = function( from, to, mimosaConfig, next ) {
 
   var imagemin = new Imagemin()
     .src(from)
-    .dest(to)
+    .dest(path.dirname(to))
     .use(Imagemin.jpegtran(opts.progressive))
     .use(Imagemin.gifsicle(opts.interlaced))
     .use(Imagemin.optipng(opts.optimizationLevel));


### PR DESCRIPTION
Previously, files would be output into `path/image.ext/image.ext`.
